### PR TITLE
fix(*): fix external buffers

### DIFF
--- a/src/frame.cc
+++ b/src/frame.cc
@@ -1066,6 +1066,7 @@ napi_value getFrameData(napi_env env, napi_callback_info info) {
   ref = f->frame->buf[0] ? av_buffer_ref(f->frame->buf[0]) : nullptr;
   size = ref ? ref->size : 0;
   curElem = 0;
+  void* resultData;
   // work through frame bufs checking whether allocation refcounts are shared
   for ( int x = 1 ; x < AV_NUM_DATA_POINTERS ; x++ ) {
     // printf("Buffer %i is %p\n", x, f->frame->data[x]);
@@ -1073,7 +1074,7 @@ napi_value getFrameData(napi_env env, napi_callback_info info) {
     size_t bufSize = size;
     if (f->frame->buf[x] == nullptr)
       bufSize = f->frame->data[x] - f->frame->data[x-1];
-    status = napi_create_external_buffer(env, bufSize, data, frameBufferFinalizer, ref, &element);
+    status = napi_create_buffer_copy(env, bufSize, data, &resultData, &element);
     CHECK_STATUS;
     status = napi_set_element(env, array, curElem, element);
     CHECK_STATUS;
@@ -1088,7 +1089,7 @@ napi_value getFrameData(napi_env env, napi_callback_info info) {
     curElem++;
   }
   if (data) {
-    status = napi_create_external_buffer(env, size, data, frameBufferFinalizer, ref, &element);
+    status = napi_create_buffer_copy(env, size, data, &resultData, &element);
     CHECK_STATUS;
     status = napi_set_element(env, array, curElem, element);
     CHECK_STATUS;

--- a/src/governor.cc
+++ b/src/governor.cc
@@ -56,7 +56,7 @@ void readComplete(napi_env env, napi_status asyncStatus, void *data) {
   }
   REJECT_STATUS;
 
-  c->status = napi_create_external_buffer(env, c->readLen, c->readBuf, readFinalizer, (void*)(uint64_t)c->readLen, &result);
+  c->status = napi_create_buffer(env, c->readLen, &c->readBuf, &result);
   REJECT_STATUS;
 
   c->status = napi_adjust_external_memory(env, c->readLen, &externalMemory);

--- a/src/packet.cc
+++ b/src/packet.cc
@@ -127,6 +127,7 @@ napi_value getPacketData(napi_env env, napi_callback_info info) {
   napi_value result;
   packetData* p;
   AVBufferRef* hintRef;
+  void* resultData;
 
   status = napi_get_cb_info(env, info, 0, nullptr, nullptr, (void**) &p);
   CHECK_STATUS;
@@ -135,8 +136,7 @@ napi_value getPacketData(napi_env env, napi_callback_info info) {
     status = napi_get_null(env, &result);
   } else {
     hintRef = av_buffer_ref(p->packet->buf);
-    status = napi_create_external_buffer(env, hintRef->size, hintRef->data,
-      packetBufferFinalizer, hintRef, &result);
+    status = napi_create_buffer_copy(env, hintRef->size, hintRef->data, &resultData, &result);
     CHECK_STATUS;
   }
 


### PR DESCRIPTION
Electron does not allow to use https://nodejs.org/api/n-api.html#napi_create_external_buffer
You can follow nodejs documentation or look at https://github.com/electron/electron/issues/35801 directly

Because of this limitation I had to run old version of electron.


This PR fixes that problem.

I tried to avoid fix this issue itself, because I was not sure how to build beamcoder, how that c++ code should look, etc. 
But it is just 3 lines of code, I tested it and it seems like it works.

I'm not sure about memory leaks.

My plan is just to release it and try to run electron on production