### PR TITLE
Add libvpx library paths for darwin and install in CI

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -21,6 +21,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - run: mkdir /tmp/beamcoder
       - run: cp -r . /tmp/beamcoder
+      - run: sudo apt-get update && sudo apt-get install -y libvpx-dev
       - run: sudo ./scripts/install_beamcoder_dependencies.sh
         working-directory: /tmp/beamcoder
       - run: yarn install --frozen-lockfile

--- a/binding.gyp
+++ b/binding.gyp
@@ -97,6 +97,10 @@
       "include_dirs": [
         "ffmpeg/ffmpeg-static-build/include"
       ],
+      "library_dirs": [
+        "/opt/homebrew/lib",
+        "/usr/local/lib"
+      ],
       "libraries": [
         "../ffmpeg/ffmpeg-static-build/lib/libavcodec.a",
         "../ffmpeg/ffmpeg-static-build/lib/libavdevice.a",


### PR DESCRIPTION
- Add libvpx path to library_dirs for macOS static builds so the linker can find libvpx
- Install libvpx-dev in github actions workflow before building
- This fixes 'library vpx not found' errors on local and in CI