### PR TITLE
Add prebuild support for faster CI installs

### DIFF
--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -1,0 +1,72 @@
+# Build and upload prebuilt binaries for faster npm install
+name: Prebuild Binaries
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  prebuild-linux:
+    runs-on: ubuntu-latest
+    env:
+      CPATH: /tmp/beamcoder/.ffmpeg/ffmpeg/include/
+      PKG_CONFIG_PATH: /tmp/beamcoder/.ffmpeg/ffmpeg/lib/pkgconfig/
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 22
+
+      - name: Get package version
+        id: version
+        run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+
+      - name: Create working directory
+        run: mkdir /tmp/beamcoder
+
+      - name: Copy source
+        run: cp -r . /tmp/beamcoder
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libvpx-dev
+
+      - name: Install FFmpeg dependencies
+        run: sudo ./scripts/install_beamcoder_dependencies.sh
+        working-directory: /tmp/beamcoder
+
+      - name: Install npm dependencies (skip native build)
+        run: npm install --ignore-scripts
+        working-directory: /tmp/beamcoder
+
+      - name: Download FFmpeg static libraries
+        run: node install_ffmpeg_static.js
+        working-directory: /tmp/beamcoder
+
+      - name: Build prebuild
+        run: npx prebuild --strip -r node -t 22.0.0
+        working-directory: /tmp/beamcoder
+        env:
+          FFMPEG_STATIC: "1"
+
+      - name: List prebuilds
+        run: ls -la /tmp/beamcoder/prebuilds/
+
+      - name: Create or update release
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          VERSION="v${{ steps.version.outputs.version }}"
+          # Check if release exists
+          if gh release view "$VERSION" >/dev/null 2>&1; then
+            echo "Release $VERSION exists, uploading prebuilds..."
+          else
+            echo "Creating release $VERSION..."
+            gh release create "$VERSION" --title "$VERSION" --notes "Prebuilt binaries for version $VERSION" --prerelease
+          fi
+          # Upload prebuilds
+          gh release upload "$VERSION" /tmp/beamcoder/prebuilds/*.tar.gz --clobber
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -6,10 +6,11 @@
   "types": "index.d.ts",
   "scripts": {
     "preinstall": "node install_ffmpeg_static.js",
-    "install": "FFMPEG_STATIC=1 node-gyp rebuild",
+    "install": "prebuild-install || (FFMPEG_STATIC=1 node-gyp rebuild)",
     "preinstall:dynamic": "node install_ffmpeg.js",
     "install:dynamic": "FFMPEG_STATIC=0 node-gyp rebuild",
     "build:dynamic": "npm run preinstall:dynamic && npm run install:dynamic",
+    "prebuild": "FFMPEG_STATIC=1 prebuild --strip",
     "test": "tape test/*.js",
     "lint": "eslint **/*.js",
     "lint-html": "eslint **/*.js -f html -o ./reports/lint-results.html",
@@ -17,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Streampunk/beamcoder.git"
+    "url": "git+https://github.com/Lumen5/beamcoder.git"
   },
   "keywords": [
     "FFmpeg",
@@ -37,10 +38,12 @@
   },
   "homepage": "https://github.com/Streampunk/beamcoder#readme",
   "dependencies": {
-    "bindings": "^1.5.0"
+    "bindings": "^1.5.0",
+    "prebuild-install": "^7.1.0"
   },
   "devDependencies": {
     "eslint": "^8.9.0",
+    "prebuild": "^13.0.0",
     "tape": "^5.5.2"
   },
   "gypfile": true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumen5/beamcoder",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Node.js native bindings to FFmpeg.",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION

- Add prebuild support to speed up `npm install` on CI
- Pre-built Linux binaries are uploaded to GitHub Releases on push to main
- Installation now tries to download prebuild first, falls back to compiling from source if unavailable (e.g., on macOS)