### PR TITLE
Use node 24 for runner.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: yarn
 
       - name: Install system dependencies (Linux)


### PR DESCRIPTION
Updates toolchain. Should not affect anything, since it's only a toolchain update. The build.yml already included builds for node 24.