### PR TITLE
Bump beamcoder version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumen5/beamcoder",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "description": "Node.js native bindings to FFmpeg.",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Bumps beamcoder to 0.0.26. Forgot to do that in the previous PR.