### PR TITLE
chore: bump remaining workflows to node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version: 24
           cache: yarn
 
       - name: Install dependencies (skip native build)
@@ -32,7 +32,7 @@ jobs:
 
       - uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version: 24
           cache: yarn
 
       - name: Install system dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org/
 
       - name: Get package version


### PR DESCRIPTION
Bumps node-version from 22 to 24 in ci.yml (2 places) and release.yml. build.yml was already on node 24. Part of the org-wide Node 24 migration.