### PR TITLE
chore: use npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,10 @@ jobs:
   release:
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      actions: read
     steps:
       - uses: actions/checkout@v5
 
@@ -17,6 +21,9 @@ jobs:
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/
+
+      - name: Update npm for trusted publishing
+        run: npm install -g npm@latest
 
       - name: Get package version
         id: version
@@ -49,5 +56,3 @@ jobs:
 
       - name: Publish to npm
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.npm_token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,6 @@ jobs:
           node-version: 24
           registry-url: https://registry.npmjs.org/
 
-      - name: Update npm for trusted publishing
-        run: npm install -g npm@latest
-
       - name: Get package version
         id: version
         run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- Switch npm publish from classic token (expired 2026-04-13) to OIDC-based trusted publishing
- Trusted publisher already registered on npmjs.com for this package + this workflow file
- LUM-72

## Test plan
- [ ] Next release tag triggers Release workflow and publishes successfully